### PR TITLE
fix: resolve frontend API configuration for production deployment

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -4,7 +4,6 @@
 
 # API Configuration (served through nginx proxy)
 VITE_API_URL=/api
-VITE_API_BASE_URL=/api
 
 # Build Environment
 NODE_ENV=production
@@ -18,9 +17,9 @@ VITE_ENVIRONMENT=production
 CORS_ORIGIN=https://your-production-domain.com
 
 # Security (REPLACE WITH STRONG SECRETS!)
-JWT_SECRET=your-secure-jwt-secret-min-32-characters
-COOKIE_SECRET=your-secure-cookie-secret-min-32-chars
-CSRF_SECRET=your-secure-csrf-secret-min-32-chars
+JWT_SECRET=CHANGE_ME_TO_SECURE_RANDOM_STRING_MIN_32_CHARS_ABCDEF123456789
+COOKIE_SECRET=CHANGE_ME_TO_SECURE_RANDOM_STRING_MIN_32_CHARS_GHIJKL987654321
+CSRF_SECRET=CHANGE_ME_TO_SECURE_RANDOM_STRING_MIN_32_CHARS_MNOPQR456789123
 
 # GitHub OAuth (configure with your production values)
 # GITHUB_CLIENT_ID=your-github-client-id
@@ -28,5 +27,7 @@ CSRF_SECRET=your-secure-csrf-secret-min-32-chars
 # GITHUB_CALLBACK_URL=https://your-domain.com/api/auth/github/callback
 
 # Infrastructure connections (configure for your infrastructure)
-MONGODB_URI=mongodb://username:password@mongodb:27017/codiesvibe?authSource=admin
-REDIS_URL=redis://:password@redis:6379
+# Example: mongodb://username:password@mongodb:27017/codiesvibe?authSource=admin
+MONGODB_URI=
+# Example: redis://:password@redis:6379
+REDIS_URL=

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,32 @@
+# Production Environment Variables for CodiesVibe
+# Copy this file to .env.production and fill in your actual values
+# NEVER commit .env.production to git!
+
+# API Configuration (served through nginx proxy)
+VITE_API_URL=/api
+VITE_API_BASE_URL=/api
+
+# Build Environment
+NODE_ENV=production
+
+# Application Metadata (optional)
+VITE_APP_NAME=CodiesVibe
+VITE_APP_VERSION=production
+VITE_ENVIRONMENT=production
+
+# CORS Configuration (for backend - replace with your domain)
+CORS_ORIGIN=https://your-production-domain.com
+
+# Security (REPLACE WITH STRONG SECRETS!)
+JWT_SECRET=your-secure-jwt-secret-min-32-characters
+COOKIE_SECRET=your-secure-cookie-secret-min-32-chars
+CSRF_SECRET=your-secure-csrf-secret-min-32-chars
+
+# GitHub OAuth (configure with your production values)
+# GITHUB_CLIENT_ID=your-github-client-id
+# GITHUB_CLIENT_SECRET=your-github-client-secret
+# GITHUB_CALLBACK_URL=https://your-domain.com/api/auth/github/callback
+
+# Infrastructure connections (configure for your infrastructure)
+MONGODB_URI=mongodb://username:password@mongodb:27017/codiesvibe?authSource=admin
+REDIS_URL=redis://:password@redis:6379

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ vite.config.ts.timestamp-*
 .cache/
 .temp/
 .tmp/
+.env.production

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,7 +8,6 @@ ARG VERSION
 
 # Build arguments for Vite environment variables
 ARG VITE_API_URL=/api
-ARG VITE_API_BASE_URL
 ARG NODE_ENV=production
 
 # Dependencies stage - Install all dependencies for caching
@@ -28,12 +27,10 @@ FROM dependencies AS builder
 
 # Re-declare ARGs needed in this stage
 ARG VITE_API_URL=/api
-ARG VITE_API_BASE_URL
 ARG NODE_ENV=production
 
 # Set environment variables from build arguments for Vite
 ENV VITE_API_URL=${VITE_API_URL}
-ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 ENV NODE_ENV=${NODE_ENV}
 
 # Copy source code first

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,6 +6,11 @@ ARG BUILD_DATE
 ARG GIT_COMMIT
 ARG VERSION
 
+# Build arguments for Vite environment variables
+ARG VITE_API_URL=/api
+ARG VITE_API_BASE_URL
+ARG NODE_ENV=production
+
 # Dependencies stage - Install all dependencies for caching
 FROM node:18-alpine AS dependencies
 
@@ -18,8 +23,18 @@ COPY package*.json ./
 # Install dependencies using npm ci for reproducible builds
 RUN npm ci
 
-# Builder stage - Build the TypeScript application  
+# Builder stage - Build the TypeScript application
 FROM dependencies AS builder
+
+# Re-declare ARGs needed in this stage
+ARG VITE_API_URL=/api
+ARG VITE_API_BASE_URL
+ARG NODE_ENV=production
+
+# Set environment variables from build arguments for Vite
+ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ENV NODE_ENV=${NODE_ENV}
 
 # Copy source code first
 COPY . .
@@ -27,7 +42,7 @@ COPY . .
 # Copy only the shared types directory that already exists (after source to override any potential conflicts)
 COPY backend/shared ./backend/shared
 
-# Build the application
+# Build the application with environment variables available
 RUN npm run build
 
 # Development stage - Hot reload development environment

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -52,13 +52,16 @@ services:
         - BUILD_DATE=${BUILD_DATE:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}
         - GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
         - VERSION=${VERSION:-latest}
+        # Vite build-time environment variables
+        - VITE_API_URL=/api
+        - NODE_ENV=production
     container_name: codiesvibe-frontend-prod
     volumes:
       # Share built files with Nginx
       - frontend_dist:/shared/dist
     environment:
       - NODE_ENV=production
-      - VITE_API_URL=/api  # Served through Nginx proxy
+      # Note: VITE_* vars are embedded at build time, these are for container metadata only
       - VITE_APP_VERSION=${VERSION:-production}
       - VITE_BUILD_DATE=${BUILD_DATE:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}
       - VITE_GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}

--- a/docs/PRODUCTION-DEPLOYMENT-GUIDE.md
+++ b/docs/PRODUCTION-DEPLOYMENT-GUIDE.md
@@ -1,0 +1,208 @@
+# Production Deployment Guide
+
+This guide explains how to properly deploy CodiesVibe in production with correct frontend-backend communication.
+
+## 🚨 The Issue We Fixed
+
+Previously, the frontend was making requests to `localhost:4000` in production, which failed because:
+1. Vite environment variables are embedded at **BUILD TIME**, not runtime
+2. The frontend container couldn't reach `localhost:4000` from within the container network
+3. Production should use nginx proxy (`/api`) instead of direct backend access
+
+## ✅ The Solution
+
+We implemented proper build-time environment variable handling:
+
+### 1. Frontend Dockerfile Changes
+```dockerfile
+# Build arguments for Vite environment variables
+ARG VITE_API_URL=/api
+ARG NODE_ENV=production
+
+# Set environment variables from build arguments
+ENV VITE_API_URL=${VITE_API_URL}
+ENV NODE_ENV=${NODE_ENV}
+```
+
+### 2. Docker Compose Production Changes
+```yaml
+frontend:
+  build:
+    args:
+      # Vite build-time environment variables
+      - VITE_API_URL=/api
+      - NODE_ENV=production
+```
+
+### 3. Frontend Code Configuration
+The frontend already had proper environment variable handling:
+```typescript
+// src/api/client.ts
+export const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '/api',
+});
+```
+
+## 🚀 How to Deploy
+
+### Prerequisites
+1. Start infrastructure services:
+   ```bash
+   docker-compose -f docker-compose.infra.yml up -d
+   ```
+
+### Step 1: Create Production Environment File
+```bash
+# Copy the example file and edit with your values
+cp .env.production.example .env.production
+
+# Edit with your actual secrets and configuration
+nano .env.production  # or your preferred editor
+```
+
+**⚠️ Important**: Never commit `.env.production` to git! It contains sensitive secrets.
+
+### Step 2: Automated Deployment (Recommended)
+```bash
+# Use the deployment script
+./scripts/deploy-production.sh
+```
+
+### Step 3: Manual Deployment (Alternative)
+```bash
+# Load production environment
+export $(cat .env.production | grep -v '^#' | xargs)
+
+# Build and deploy
+docker-compose -f docker-compose.production.yml up -d --build
+
+# Verify deployment
+curl http://localhost/health      # Frontend
+curl http://localhost/api/health  # Backend through nginx
+```
+
+## 🔍 Debugging
+
+### Verify API Configuration in Built Files
+```bash
+# Run the debug script
+./scripts/debug-api-config.sh
+```
+
+This script will:
+- Extract built frontend files
+- Search for hardcoded localhost references
+- Verify `/api` configuration is embedded
+- Test the frontend container
+
+### Expected Debug Results
+```
+✅ No localhost references found
+✅ Found /api references in built files
+✅ No port 4000 references found
+✅ Found baseURL configuration in built file
+```
+
+### Manual Verification
+```bash
+# Check if frontend makes correct API calls
+docker logs codiesvibe-nginx
+
+# Should show requests to backend:4000, not localhost:4000
+```
+
+## 🌐 Architecture
+
+```
+Browser → Nginx (port 80) → Backend (internal port 4000)
+                ↓
+           Static Files (Frontend)
+```
+
+- **Frontend**: Built with `/api` as base URL, served by nginx
+- **Backend**: Accessible only through nginx proxy at `/api/*`
+- **nginx**: Routes `/api/*` to backend, serves static files for everything else
+
+## 🔧 Environment Variables
+
+### Build-time Variables (Embedded in Frontend)
+```env
+VITE_API_URL=/api          # Required for production
+NODE_ENV=production        # Required for optimization
+```
+
+### Runtime Variables (Backend/Infrastructure)
+```env
+MONGODB_URI=mongodb://admin:password123@mongodb:27017/codiesvibe?authSource=admin
+REDIS_URL=redis://:redis123@redis:6379
+JWT_SECRET=your-jwt-secret
+CORS_ORIGIN=https://your-domain.com
+```
+
+## 🚨 Common Issues
+
+### Issue: Frontend still shows localhost:4000 in browser network tab
+**Cause**: Old build cached or environment variables not passed at build time
+**Fix**:
+```bash
+docker-compose -f docker-compose.production.yml build --no-cache frontend
+```
+
+### Issue: 502 Bad Gateway for /api requests
+**Cause**: Backend not accessible from nginx
+**Fix**:
+```bash
+# Check if backend is running
+docker logs codiesvibe-backend-prod
+
+# Check network connectivity
+docker exec codiesvibe-nginx curl http://backend:4000/health
+```
+
+### Issue: Frontend shows blank page
+**Cause**: Build failed or static files not served correctly
+**Fix**:
+```bash
+# Check frontend build logs
+docker logs codiesvibe-frontend-prod
+
+# Verify static files exist
+docker exec codiesvibe-nginx ls -la /usr/share/nginx/html/
+```
+
+## 📋 Health Checks
+
+After deployment, verify these endpoints:
+
+- **Frontend**: `http://localhost/` - Should load the React app
+- **Backend**: `http://localhost/api/health` - Should return `{"status":"ok"}`
+- **nginx**: `http://localhost/nginx-health` - Should return `healthy`
+- **API**: `http://localhost/api/tools` - Should return tools data
+
+## 🔐 Security Considerations
+
+1. **Secrets**: Use proper secrets management in real production
+2. **HTTPS**: Configure SSL/TLS certificates for production domain
+3. **CORS**: Update `CORS_ORIGIN` to your actual domain
+4. **Rate Limiting**: nginx includes rate limiting configuration
+5. **Security Headers**: nginx adds comprehensive security headers
+
+## 📝 Files Created/Modified
+
+- `Dockerfile.frontend` - Added build-time environment variable support
+- `docker-compose.production.yml` - Added build args for environment variables
+- `.env.production` - Production environment configuration
+- `scripts/deploy-production.sh` - Automated deployment script
+- `scripts/debug-api-config.sh` - Debug and verification script
+- `docs/PRODUCTION-DEPLOYMENT-GUIDE.md` - This guide
+
+## ✅ Success Verification
+
+Your deployment is successful when:
+1. No `localhost:4000` references in browser network tab
+2. API calls go to `/api/*` paths
+3. All health checks pass
+4. No 502 errors in nginx logs
+5. Application functions normally
+
+For issues or questions, check the nginx and backend container logs for detailed error information.

--- a/scripts/debug-api-config.sh
+++ b/scripts/debug-api-config.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Debug script to verify API configuration in built frontend files
+
+set -e
+
+echo "🔍 Debugging API Configuration in Frontend Build..."
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_status() {
+    echo -e "${BLUE}[DEBUG]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if frontend container exists
+if ! docker images | grep -q "codiesvibe-frontend"; then
+    print_error "Frontend image not found. Please run: docker-compose -f docker-compose.production.yml build frontend"
+    exit 1
+fi
+
+# Create temporary container to inspect build files
+print_status "Creating temporary container to inspect build files..."
+TEMP_CONTAINER=$(docker create codiesvibe-frontend:latest)
+
+# Extract built JavaScript files
+print_status "Extracting built files..."
+mkdir -p /tmp/codiesvibe-debug
+docker cp $TEMP_CONTAINER:/usr/share/nginx/html /tmp/codiesvibe-debug/
+
+# Clean up temporary container
+docker rm $TEMP_CONTAINER
+
+# Search for API URLs in built files
+print_status "Searching for API configurations in built files..."
+
+echo "=== Searching for 'localhost' references ==="
+if grep -r "localhost" /tmp/codiesvibe-debug/html/ 2>/dev/null; then
+    print_error "Found localhost references in built files!"
+else
+    print_success "No localhost references found"
+fi
+
+echo "=== Searching for API URL configurations ==="
+if grep -r "/api" /tmp/codiesvibe-debug/html/ 2>/dev/null; then
+    print_success "Found /api references in built files"
+else
+    print_error "No /api references found in built files"
+fi
+
+echo "=== Searching for 4000 port references ==="
+if grep -r "4000" /tmp/codiesvibe-debug/html/ 2>/dev/null; then
+    print_error "Found port 4000 references in built files!"
+else
+    print_success "No port 4000 references found"
+fi
+
+echo "=== Environment variable patterns ==="
+grep -r "VITE_API" /tmp/codiesvibe-debug/html/ 2>/dev/null || echo "No VITE_API references (expected - they should be replaced)"
+
+echo "=== Index.html content preview ==="
+head -20 /tmp/codiesvibe-debug/html/index.html
+
+echo "=== Built JavaScript file analysis ==="
+JS_FILE=$(find /tmp/codiesvibe-debug/html/assets -name "*.js" | head -1)
+if [ -f "$JS_FILE" ]; then
+    echo "Analyzing: $JS_FILE"
+    echo "File size: $(du -h "$JS_FILE" | cut -f1)"
+
+    # Look for baseURL configuration
+    if grep -o "baseURL[^,}]*" "$JS_FILE" 2>/dev/null; then
+        print_success "Found baseURL configuration in built file"
+    else
+        print_error "No baseURL configuration found"
+    fi
+else
+    print_error "No JavaScript files found in build"
+fi
+
+# Test with temporary container
+print_status "Testing API configuration with temporary container..."
+TEMP_CONTAINER=$(docker run -d -p 3001:80 codiesvibe-frontend:latest)
+sleep 2
+
+# Test if the frontend loads
+if curl -f http://localhost:3001/ >/dev/null 2>&1; then
+    print_success "Frontend container is serving content on port 3001"
+
+    # Download and check the main JS file for API configuration
+    MAIN_JS=$(curl -s http://localhost:3001/ | grep -o 'assets/[^"]*\.js' | head -1)
+    if [ -n "$MAIN_JS" ]; then
+        print_status "Downloading main JavaScript file: $MAIN_JS"
+        curl -s "http://localhost:3001/$MAIN_JS" > /tmp/main.js
+
+        if grep -q "/api" /tmp/main.js; then
+            print_success "✅ API configuration correctly embedded as '/api'"
+        else
+            print_error "❌ API configuration not found or incorrect"
+        fi
+
+        if grep -q "localhost" /tmp/main.js; then
+            print_error "❌ Found localhost references in production build"
+        else
+            print_success "✅ No localhost references in production build"
+        fi
+    fi
+else
+    print_error "Frontend container failed to serve content"
+fi
+
+# Cleanup
+docker stop $TEMP_CONTAINER >/dev/null 2>&1
+docker rm $TEMP_CONTAINER >/dev/null 2>&1
+rm -rf /tmp/codiesvibe-debug
+rm -f /tmp/main.js
+
+print_status "Debug completed!"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# CodiesVibe Production Deployment Script
+# This script ensures proper environment setup and deploys the production environment
+
+set -e  # Exit on any error
+
+echo "🚀 Starting CodiesVibe Production Deployment..."
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if required files exist
+print_status "Checking required files..."
+if [ ! -f "docker-compose.production.yml" ]; then
+    print_error "docker-compose.production.yml not found!"
+    exit 1
+fi
+
+if [ ! -f ".env.production" ]; then
+    print_error ".env.production not found!"
+    print_status "Please create it from the example file:"
+    print_status "  cp .env.production.example .env.production"
+    print_status "  nano .env.production  # Edit with your actual values"
+    exit 1
+fi
+
+# Load production environment variables
+if [ -f ".env.production" ]; then
+    print_status "Loading production environment variables..."
+    export $(cat .env.production | grep -v '^#' | xargs)
+fi
+
+# Check if infrastructure is running
+print_status "Checking infrastructure services..."
+if ! docker network ls | grep -q "codiesvibe-network"; then
+    print_error "Infrastructure network not found. Please run: docker-compose -f docker-compose.infra.yml up -d"
+    exit 1
+fi
+
+# Check if MongoDB is accessible
+print_status "Checking MongoDB connection..."
+if ! docker exec mongodb mongosh --eval "db.adminCommand('ping')" >/dev/null 2>&1; then
+    print_error "MongoDB is not accessible. Please check infrastructure services."
+    exit 1
+fi
+
+# Stop existing production services
+print_status "Stopping existing production services..."
+docker-compose -f docker-compose.production.yml down --remove-orphans
+
+# Build and start production services
+print_status "Building and starting production services..."
+docker-compose -f docker-compose.production.yml up -d --build
+
+# Wait for services to be ready
+print_status "Waiting for services to start..."
+sleep 30
+
+# Health checks
+print_status "Performing health checks..."
+
+# Check nginx
+if curl -f http://localhost/health >/dev/null 2>&1; then
+    print_success "Nginx is healthy"
+else
+    print_error "Nginx health check failed"
+fi
+
+# Check backend through nginx
+if curl -f http://localhost/api/health >/dev/null 2>&1; then
+    print_success "Backend is accessible through nginx"
+else
+    print_error "Backend health check failed"
+fi
+
+# Check frontend
+if curl -f http://localhost/ >/dev/null 2>&1; then
+    print_success "Frontend is serving content"
+else
+    print_error "Frontend health check failed"
+fi
+
+# Display service status
+print_status "Production deployment status:"
+docker-compose -f docker-compose.production.yml ps
+
+print_success "🎉 Production deployment completed!"
+print_status "Application is available at: http://localhost"
+print_status "API documentation: http://localhost/docs"
+print_status "Health endpoints:"
+print_status "  Frontend: http://localhost/"
+print_status "  Backend: http://localhost/api/health"
+print_status "  Nginx: http://localhost/nginx-health"
+
+# Display container logs for debugging
+print_status "Recent logs from services:"
+echo "--- Frontend Logs ---"
+docker logs codiesvibe-frontend-prod --tail 10
+echo "--- Backend Logs ---"
+docker logs codiesvibe-backend-prod --tail 10
+echo "--- Nginx Logs ---"
+docker logs codiesvibe-nginx --tail 10


### PR DESCRIPTION
- Fix Dockerfile.frontend to pass VITE_API_URL as build argument
- Update docker-compose.production.yml to provide build-time environment variables
- Add .env.production.example with placeholder values for production setup
- Add production deployment script with health checks and validation
- Add debug script to verify API configuration in built files
- Update .gitignore to exclude .env.production from version control
- Create comprehensive production deployment guide

The issue was that Vite embeds environment variables at BUILD TIME, not runtime. Frontend now correctly connects to backend through nginx proxy.

Security: Sensitive environment variables are excluded from git history. Users must create .env.production from the example file with their own secrets.

🤖 Generated with [Claude Code](https://claude.ai/code)