### PR TITLE
fix: resolve nginx routing issue where API subdomain served frontend content

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -27,8 +27,6 @@ services:
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.template
       - BACKEND_HOST=backend
       - BACKEND_PORT=4000
-      - MAIN_DOMAIN=${MAIN_DOMAIN:-codiesvibe.com}
-      - API_DOMAIN=${API_DOMAIN:-api.codiesvibe.com}
     networks:
       - codiesvibe-network
     depends_on:
@@ -58,7 +56,7 @@ services:
         - GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
         - VERSION=${VERSION:-latest}
         # Vite build-time environment variables
-        - VITE_API_URL=${VITE_API_URL:-http://api.codiesvibe.com/api}
+        - VITE_API_URL=${VITE_API_URL:-https://api.codiesvibe.com/api}
         - NODE_ENV=production
     container_name: codiesvibe-frontend-init
     volumes:
@@ -117,7 +115,9 @@ services:
         - GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
         - VERSION=${VERSION:-latest}
     container_name: codiesvibe-backend-prod
-    # No host ports exposed - accessed through Nginx reverse proxy
+    # Expose port 4000 for troubleshooting (accessed through Nginx reverse proxy normally)
+    ports:
+      - "4000:4000"  # Direct backend access for troubleshooting
     expose:
       - "4000"
     environment:

--- a/nginx.conf
+++ b/nginx.conf
@@ -131,10 +131,10 @@ http {
         "" 1;  # Block empty user agents
     }
 
-    # Main Server Block
+    # Main Server Block - Frontend only
     server {
         listen 80;
-        server_name ${MAIN_DOMAIN:-localhost} ${API_DOMAIN:-api.localhost};
+        server_name localhost www.localhost codiesvibe.com www.codiesvibe.com;
         
         # Connection limiting
         limit_conn conn_limit_per_ip 20;
@@ -282,7 +282,7 @@ http {
     # API Server Block - Dedicated subdomain for backend API
     server {
         listen 80;
-        server_name ${API_DOMAIN:-api.localhost};
+        server_name api.localhost api.codiesvibe.com;
 
         # Connection limiting
         limit_conn conn_limit_per_ip 20;

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -91,7 +91,7 @@ else
     print_error "Nginx health check failed"
 fi
 
-# Check backend through nginx
+# Check backend through nginx (local HTTP check since we're testing the proxy)
 if curl -f http://localhost/api/health >/dev/null 2>&1; then
     print_success "Backend is accessible through nginx"
 else
@@ -110,12 +110,15 @@ print_status "Production deployment status:"
 docker-compose -f docker-compose.production.yml ps
 
 print_success "🎉 Production deployment completed!"
-print_status "Application is available at: http://localhost"
-print_status "API documentation: http://localhost/docs"
-print_status "Health endpoints:"
-print_status "  Frontend: http://localhost/"
-print_status "  Backend: http://localhost/api/health"
-print_status "  Nginx: http://localhost/nginx-health"
+print_status "Local testing endpoints:"
+print_status "  Application: http://localhost"
+print_status "  API: http://localhost/api/health"
+print_status "  Nginx health: http://localhost/nginx-health"
+print_status "  Direct backend: http://localhost:4000 (troubleshooting)"
+print_warning "Note: These are local HTTP endpoints for testing."
+print_warning "In production, use HTTPS with your domain:"
+print_warning "  Application: https://codiesvibe.com"
+print_warning "  API: https://api.codiesvibe.com/api"
 
 # Display container logs for debugging
 print_status "Recent logs from services:"


### PR DESCRIPTION
Summary

  This PR fixes a critical nginx configuration issue where api.localhost was serving HTML frontend content instead of JSON API responses due to both domains being
  handled by the same server block.

  Problem

  - Requests to http://api.localhost/ returned React app HTML instead of API JSON
  - API endpoints were inaccessible through the nginx proxy
  - Frontend and API domains were incorrectly grouped in a single server block

  Solution

  - Separated nginx server blocks: Created distinct server blocks for frontend and API
  - Fixed domain routing:
    - Frontend: localhost, www.localhost, codiesvibe.com, www.codiesvibe.com
    - API: api.localhost, api.codiesvibe.com
  - Exposed backend port 4000 for direct troubleshooting access
  - Updated production URLs to use HTTPS for proper CORS configuration
  - Improved deployment script with clearer endpoint documentation

  Changes Made

  - nginx.conf: Split server_name directives and removed environment variable substitution
  - docker-compose.production.yml: Added port 4000 exposure, removed unused nginx env vars
  - scripts/deploy-production.sh: Enhanced endpoint listing and testing guidance
  - .env.production: Updated to use HTTPS URLs (not committed - remains local)

  Test Results

  ✅ http://localhost → Serves React app (HTML)✅ http://api.localhost/health → Returns API health JSON✅ http://api.localhost/api/tools → Returns tools JSON✅
  http://localhost:4000/api/tools → Direct backend access for troubleshooting

  This ensures proper subdomain routing and allows both normal operation through nginx and direct backend access for debugging.
