### PR TITLE
feat: disable authentication for search functionality

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -56,7 +56,7 @@ export class AuthController {
       sameSite: isProduction ? 'none' : 'strict', // 'none' for cross-subdomain in production
       maxAge: 15 * 60 * 1000, // 15 minutes
       path: '/',
-      ...(isProduction && { domain: '.codiesvibe.com' }), // Work across all subdomains
+      // Removed explicit domain to let browser handle it automatically (fixes Cloudflare tunnel issues)
     });
 
     return session;
@@ -141,7 +141,7 @@ export class AuthController {
       sameSite: isProduction ? 'none' : 'strict', // 'none' for cross-subdomain in production
       maxAge: 15 * 60 * 1000, // 15 minutes
       path: '/',
-      ...(isProduction && { domain: '.codiesvibe.com' }), // Work across all subdomains
+      // Removed explicit domain to let browser handle it automatically (fixes Cloudflare tunnel issues)
     });
 
     return newSession;

--- a/backend/src/tools/tools.controller.ts
+++ b/backend/src/tools/tools.controller.ts
@@ -25,7 +25,7 @@ export class ToolsController {
   ) {}
 
   @Post('ai-search')
-  @RequireSession()
+  // @RequireSession() - Temporarily disabled for testing
   @ApiOperation({
     summary: 'AI based searching (POST with session validation)',
   })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,26 +4,27 @@ import axios from 'axios';
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'https://api.codiesvibe.com/api',
   timeout: 10000,
-  withCredentials: true, // Important for cross-subdomain cookies
+  withCredentials: false, // Disabled for testing - re-enable later
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// Request interceptor to add CSRF token
+// Request interceptor to add CSRF token - TEMPORARILY DISABLED
 apiClient.interceptors.request.use(async (config) => {
+  // CSRF disabled for testing - re-enable later
   // Add CSRF token for POST, PUT, PATCH, DELETE requests
-  if (['post', 'put', 'patch', 'delete'].includes(config.method?.toLowerCase() || '')) {
-    try {
-      // Try to get CSRF token from session hook or make a request
-      const csrfResponse = await axios.get(`${import.meta.env.VITE_API_URL || '/api'}/auth/csrf`, {
-        withCredentials: true,
-      });
-      config.headers['X-CSRF-Token'] = csrfResponse.data.csrfToken;
-    } catch (error) {
-      console.warn('Failed to get CSRF token:', error);
-    }
-  }
+  // if (['post', 'put', 'patch', 'delete'].includes(config.method?.toLowerCase() || '')) {
+  //   try {
+  //     // Try to get CSRF token from session hook or make a request
+  //     const csrfResponse = await axios.get(`${import.meta.env.VITE_API_URL || '/api'}/auth/csrf`, {
+  //       withCredentials: true,
+  //     });
+  //     config.headers['X-CSRF-Token'] = csrfResponse.data.csrfToken;
+  //   } catch (error) {
+  //     console.warn('Failed to get CSRF token:', error);
+  //   }
+  // }
   return config;
 });
 


### PR DESCRIPTION
   - Remove explicit cookie domain to fix Cloudflare tunnel issues
   - Temporarily disable @RequireSession() decorator on ai-search endpoint
   - Disable CSRF token requirement and credentials in frontend API client
   - Allow search functionality to work without authentication