### PR TITLE
refactor(search-api): update search endpoint path

### DIFF
--- a/search-api/openapi.yaml
+++ b/search-api/openapi.yaml
@@ -43,7 +43,7 @@ tags:
     description: Prometheus metrics for monitoring
 
 paths:
-  /search:
+  /api/search:
     post:
       tags:
         - Search

--- a/search-api/src/server.ts
+++ b/search-api/src/server.ts
@@ -683,7 +683,7 @@ function sanitizeQuery(query: string): string {
 }
 
 // Enhanced search endpoint with comprehensive security
-app.post('/search', searchLimiter, searchTimeout, validateSearchRequest, async (req, res) => {
+app.post('/api/search', searchLimiter, searchTimeout, validateSearchRequest, async (req, res) => {
   const startTime = Date.now();
   const searchReq = req as SearchRequest;
   const clientId = req.ip || req.socket.remoteAddress || 'unknown';
@@ -843,7 +843,7 @@ async function startServer() {
       healthReadyEndpoint: `http://localhost:${PORT}/health/ready`,
       metricsEndpoint: `http://localhost:${PORT}/metrics`,
       apiDocsEndpoint: `http://localhost:${PORT}/api-docs`,
-      searchEndpoint: `http://localhost:${PORT}/search`,
+      searchEndpoint: `http://localhost:${PORT}/api/search`,
       environment: process.env.NODE_ENV || 'development'
     });
     searchLogger.info('Server endpoints available', {


### PR DESCRIPTION
Standardize API endpoint paths by prefixing with /api for better consistency and organization