### PR TITLE
fix(ci): handle missing package in search-api cleanup job

### DIFF
--- a/.github/workflows/search-api-ci-cd.yml
+++ b/.github/workflows/search-api-ci-cd.yml
@@ -532,6 +532,7 @@ jobs:
     steps:
       - name: Delete old search-api packages
         uses: actions/delete-package-versions@v5
+        continue-on-error: true  # Don't fail if package doesn't exist yet
         with:
           package-name: ${{ env.IMAGE_NAME }}
           package-type: 'container'


### PR DESCRIPTION
Add continue-on-error to delete-package-versions step to prevent pipeline failure when the container package doesn't exist yet (first deployment or after package deletion).